### PR TITLE
Properly handle the case where there is no artifacts file

### DIFF
--- a/lib/artifacts.sh
+++ b/lib/artifacts.sh
@@ -4,6 +4,9 @@ set -euo pipefail
 
 artifact_contents() {
     local -r _artifact_name="${1}"
-    buildkite-agent artifact download "${_artifact_name}" .
-    jq -r '.' "${_artifact_name}"
+    if (buildkite-agent artifact download "${_artifact_name}" .); then
+        jq -r '.' "${_artifact_name}"
+    else
+        echo '{}'
+    fi
 }

--- a/lib/artifacts_test.sh
+++ b/lib/artifacts_test.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+
+# mock `buildkite-agent` binary
+buildkite-agent() {
+    echo "${FUNCNAME[0]} $*" >> "${ALL_COMMANDS}"
+
+    case "$*" in
+        artifact\ download\ existing_file.json\ .)
+            echo '{"foo": "1.2.3"}' > existing_file.json
+            ;;
+        artifact\ download\ non_existent_file.json\ .)
+            return 1
+            ;;
+        *)
+            return 2
+            ;;
+    esac
+}
+
+recorded_commands() {
+    if [ -f "${ALL_COMMANDS}" ]; then
+        cat "${ALL_COMMANDS}"
+    fi
+}
+
+oneTimeSetUp() {
+    export BUILDKITE_BUILD_URL="https://buildkite.com/grapl/pipeline-infrastructure-verify/builds/2112"
+    export ALL_COMMANDS="${SHUNIT_TMPDIR}/all_commands"
+
+    # shellcheck source-path=SCRIPTDIR
+    source "$(dirname "${BASH_SOURCE[0]}")/artifacts.sh"
+}
+
+setUp() {
+    # Ensure any recorded commands from the last test are removed so
+    # we start with a clean slate.
+    rm -f "${ALL_COMMANDS}"
+}
+
+test_artifact_contents_existing_file() {
+
+    output=$(artifact_contents existing_file.json)
+    expected_output=$(
+        cat << EOF
+{
+  "foo": "1.2.3"
+}
+EOF
+    )
+
+    expected_commands=$(
+        cat << EOF
+buildkite-agent artifact download existing_file.json .
+EOF
+    )
+
+    assertEquals "The expected output did not match" \
+        "${expected_output}" \
+        "${output}"
+
+    assertEquals "The expected buildkite-agent commands were not run" \
+        "${expected_commands}" \
+        "$(recorded_commands)"
+}
+
+test_artifact_contents_non_existent_file() {
+
+    output=$(artifact_contents non_existent_file.json)
+    expected_output="{}"
+
+    expected_commands=$(
+        cat << EOF
+buildkite-agent artifact download non_existent_file.json .
+EOF
+    )
+
+    assertEquals "The expected output did not match" \
+        "${expected_output}" \
+        "${output}"
+
+    assertEquals "The expected buildkite-agent commands were not run" \
+        "${expected_commands}" \
+        "$(recorded_commands)"
+}


### PR DESCRIPTION
Due to the dynamic nature of our pipelines, there aren't necessarily
new artifacts to process. At the moment, we still create a release
candidate, though (to account for e.g., changes in Pulumi code
itself).

Signed-off-by: Christopher Maier <chris@graplsecurity.com>