### PR TITLE
Continue to work even with shallow clones / fetches

### DIFF
--- a/lib/rc.sh
+++ b/lib/rc.sh
@@ -174,6 +174,12 @@ create_rc() {
     pulumi login
 
     echo -e "--- :git: Checking out the rc branch"
+
+    # We run our pipelines in Buildkite using shallow clones, which
+    # means that checking out a separate branch doesn't work without
+    # some extra steps.
+    git remote set-branches --add origin rc
+    git fetch --depth=1 origin rc
     git checkout rc
 
     echo -e "--- :git: Begin merge of main branch to rc"

--- a/lib/rc_test.sh
+++ b/lib/rc_test.sh
@@ -233,6 +233,8 @@ test_create_rc_webhook() {
     expected=$(
         cat << EOF
 pulumi login
+git remote set-branches --add origin rc
+git fetch --depth=1 origin rc
 git checkout rc
 git config user.name Testy McTestface
 git config user.email tests@example.com

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -46,7 +46,10 @@ teardown() {
          "config set --path artifacts.foo 1.2.3 --cwd=pulumi/cicd --stack=myorg/cicd/testing : echo 'set foo in testing'" \
          "config set --path artifacts.bar 4.5.6 --cwd=pulumi/cicd --stack=myorg/cicd/testing : echo 'set bar in testing'"
 
-    stub git "checkout rc : echo 'checking out rc'" \
+    stub git \
+         "remote set-branches --add origin rc : echo 'set-branches'" \
+         "fetch --depth=1 origin rc : echo 'fetch rc'" \
+         "checkout rc : echo 'checking out rc'" \
          "config user.name 'Testy McTestface' : echo 'set user.name'" \
          "config user.email tests@example.com : echo 'set user.email'" \
          "merge --no-ff --no-commit --strategy=recursive --strategy-option=ours main : echo 'begin merge'" \


### PR DESCRIPTION
We can no longer assume that an `rc` branch reference exists, now that
we use shallow clones.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>