### PR TITLE
Perform merge with --allow-unrelated-histories

### DIFF
--- a/lib/rc.sh
+++ b/lib/rc.sh
@@ -178,6 +178,9 @@ create_rc() {
     # We run our pipelines in Buildkite using shallow clones, which
     # means that checking out a separate branch doesn't work without
     # some extra steps.
+    #
+    # See the `--allow-unrelated-histories` option to `git merge`
+    # below, too.
     git remote set-branches --add origin rc
     git fetch --depth=1 origin rc
     git checkout rc
@@ -196,11 +199,18 @@ create_rc() {
     # involve the Pulumi stack config files, which is exactly what we
     # want). As we process the files further, we'll resolve any
     # semantic changes we truly wish to preserve.
+    #
+    # `--allow-unrelated-histories` will allow us to perform a merge,
+    # even though we've only shallowly-fetched our `main` and `rc`
+    # branches; they will *appear* unrelated based on the current
+    # state of the repository, but we know they really are related in
+    # a full checkout.
     git merge \
         --no-ff \
         --no-commit \
         --strategy=recursive \
         --strategy-option=ours \
+        --allow-unrelated-histories \
         main
 
     for stack_ref in "${stack_references[@]}"; do

--- a/lib/rc_test.sh
+++ b/lib/rc_test.sh
@@ -238,7 +238,7 @@ git fetch --depth=1 origin rc
 git checkout rc
 git config user.name Testy McTestface
 git config user.email tests@example.com
-git merge --no-ff --no-commit --strategy=recursive --strategy-option=ours main
+git merge --no-ff --no-commit --strategy=recursive --strategy-option=ours --allow-unrelated-histories main
 pulumi config get artifacts --cwd=pulumi/cicd --stack=myorg/cicd/production
 git show main:pulumi/cicd/Pulumi.production.yaml
 git add --verbose pulumi/cicd/Pulumi.production.yaml

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -52,7 +52,7 @@ teardown() {
          "checkout rc : echo 'checking out rc'" \
          "config user.name 'Testy McTestface' : echo 'set user.name'" \
          "config user.email tests@example.com : echo 'set user.email'" \
-         "merge --no-ff --no-commit --strategy=recursive --strategy-option=ours main : echo 'begin merge'" \
+         "merge --no-ff --no-commit --strategy=recursive --strategy-option=ours --allow-unrelated-histories main : echo 'begin merge'" \
          "show main:pulumi/cicd/Pulumi.production.yaml : echo 'FAKE PRODUCTION STACK CONFIGURATION'" \
          "add --verbose pulumi/cicd/Pulumi.production.yaml : echo 'add stack file'" \
          "show main:pulumi/cicd/Pulumi.testing.yaml : echo 'FAKE TESTING STACK CONFIGURATION'" \


### PR DESCRIPTION
With our shallow clones, fetching only the tips of `main` and `rc`, we
were not able to actually perform a merge, receiving the following
error:

    fatal: refusing to merge unrelated histories

Based on the contents of the local checkout, these branches did really
appear to be unrelated, but only because we didn't have the entire
history; if we were to do a full clone, they would of course be
related.

Rather than trying to fetch code until we get to the most recent
common ancestor of both branches (or do a full fetch, which rather
defeats the point of shallow clones in the first place), we can
instead just tell `git` to ignore this situation and perform a merge
anyway.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>