### PR TITLE
Add org to 'toolchain-setup' configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ practices develop over time.
 steps:
   - label: ":medal: Create new release candidate"
     plugins:
-      - grapl-security/grapl-rc#v0.1.1:
+      - grapl-security/grapl-rc#v0.1.2:
           project_root_dir: pulumi
           artifact_file: all_artifacts.json
           stacks:

--- a/pants.toml
+++ b/pants.toml
@@ -27,6 +27,7 @@ remote_store_address = "grpcs://cache.toolchain.com:443"
 remote_auth_plugin = "toolchain.pants.auth.plugin:toolchain_auth_plugin"
 
 [toolchain-setup]
+org = "grapl-security"
 repo = "grapl-rc-buildkite-plugin"
 
 [buildsense]


### PR DESCRIPTION
This is a new configuration that will be required for version 0.17.0 of the Toolchain plugin

Signed-off-by: Christopher Maier <chris@graplsecurity.com>
