### PR TITLE
Ensure we're operating on "real" (not grafted) commits

### DIFF
--- a/lib/rc_test.sh
+++ b/lib/rc_test.sh
@@ -234,8 +234,10 @@ test_create_rc_webhook() {
         cat << EOF
 pulumi login
 git remote set-branches --add origin rc
-git fetch --depth=1 origin rc
+git fetch --depth=2 origin rc
 git checkout rc
+git --no-pager show
+git log --oneline --decorate --max-count=1
 git config user.name Testy McTestface
 git config user.email tests@example.com
 git merge --no-ff --no-commit --strategy=recursive --strategy-option=ours --allow-unrelated-histories main

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -48,8 +48,10 @@ teardown() {
 
     stub git \
          "remote set-branches --add origin rc : echo 'set-branches'" \
-         "fetch --depth=1 origin rc : echo 'fetch rc'" \
+         "fetch --depth=2 origin rc : echo 'fetch rc'" \
          "checkout rc : echo 'checking out rc'" \
+         "--no-pager show : echo 'showing the tip of rc'" \
+         "log --oneline --decorate --max-count=1 : echo 'deadbeef (HEAD -> rc, origin/rc) Create new release candidate'" \
          "config user.name 'Testy McTestface' : echo 'set user.name'" \
          "config user.email tests@example.com : echo 'set user.email'" \
          "merge --no-ff --no-commit --strategy=recursive --strategy-option=ours --allow-unrelated-histories main : echo 'begin merge'" \


### PR DESCRIPTION
After rolling out the ability to work on shallow clones, we noticed
some problems generating the merge commit from `main` to `rc`, in that
certain changes from the `main` branch were being excluded from the
merge.

This appears to have been because our `rc` commit, being the tip of a
`depth=1` shallowly-fetched branch, was what is known as a "grafted"
commit, which means it effectively contains the entire history of that
branch in a single commit. Because of how this interacted with our
merging strategy and our `--allow-unrelated-histories` option, we
ended up privigeling *too much* content on the `rc` branch, instead of
from the `main` branch during the merge.

Here, we switch to a `depth=2` fetch, which ensures that the tip is
actually a real commit, and does not contain the entire history.

We *will* need to make some additional commits to the various `rc`
branches that have been affected by this code, to ensure they pick up
all the code changes they need. Once that is done, however, the
current commit should ensure that things work properly going forward.

As a further guard, we now explicitly test to make sure the tip of the
`rc` branch is not a grafted commit.

Further detail is contained in code comments.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>