### PR TITLE
Re-do RC logic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,10 @@ test-shell:
 
 .PHONY: test-plugin
 test-plugin:
-	docker-compose run --rm plugin-tester
+	# Only running `build` here to ensure we have our latest changes
+	# to the plugin-tester container; see plugin-tester.Dockerfile for
+	# more.
+	docker-compose build && docker-compose run --rm plugin-tester
 
 .PHONY: all
 all: format lint test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,10 @@ x-common-variables:
 
 services:
   plugin-tester:
-    image: buildkite/plugin-tester:latest # the only available tag
+    build:
+      context: .
+      dockerfile: plugin-tester.Dockerfile
+    image: grapl-plugin-tester:latest
     volumes:
       - *read-only-plugin
 

--- a/lib/artifacts.sh
+++ b/lib/artifacts.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
-
 artifact_contents() {
     local -r _artifact_name="${1}"
     if (buildkite-agent artifact download "${_artifact_name}" .); then

--- a/lib/json_tools.sh
+++ b/lib/json_tools.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
-
 flatten_json() {
     # The purpose of this module is to convert something like the following json:
     # {

--- a/lib/log.sh
+++ b/lib/log.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
-
 log() {
     echo -e "${@}" >&2
 }

--- a/lib/rc.sh
+++ b/lib/rc.sh
@@ -194,7 +194,7 @@ create_rc() {
     git config user.name "${GIT_AUTHOR_NAME}"
     git config user.email "${GIT_AUTHOR_EMAIL}"
 
-    # We use the recursive/ours strategy here to preserve the
+    # We use the ort/ours strategy here to preserve the
     # conflicts from the rc branch preferentially (this should only
     # involve the Pulumi stack config files, which is exactly what we
     # want). As we process the files further, we'll resolve any
@@ -208,7 +208,7 @@ create_rc() {
     git merge \
         --no-ff \
         --no-commit \
-        --strategy=recursive \
+        --strategy=ort \
         --strategy-option=ours \
         --allow-unrelated-histories \
         main

--- a/lib/rc.sh
+++ b/lib/rc.sh
@@ -228,7 +228,7 @@ create_rc() {
     echo -e "--- :git: Finalizing commit"
     git commit \
         --message="$(commit_message "${new_artifacts}")"
-    git --no-pager show
+    git --no-pager show -m
 
     # Finally, push it up to Github!
     if is_real_run; then

--- a/lib/rc.sh
+++ b/lib/rc.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
-
 # shellcheck source-path=SCRIPTDIR
 source "$(dirname "${BASH_SOURCE[0]}")/json_tools.sh"
 # shellcheck source-path=SCRIPTDIR

--- a/lib/rc_test.sh
+++ b/lib/rc_test.sh
@@ -261,7 +261,7 @@ git add --verbose pulumi/cicd/Pulumi.testing.yaml
 git commit --message=Create new release candidate
 
 Generated from https://buildkite.com/grapl/pipeline-infrastructure-verify/builds/2112
-git --no-pager show
+git --no-pager show -m
 git push --verbose
 EOF
     )

--- a/lib/rc_test.sh
+++ b/lib/rc_test.sh
@@ -36,6 +36,13 @@ git() {
     echo "${FUNCNAME[0]} $*" >> "${ALL_COMMANDS}"
 }
 
+mktemp() {
+    # Note: we don't get arguments
+    echo "${FUNCNAME[0]}" >> "${ALL_COMMANDS}"
+
+    touch "/tmp/tmp.XXXXXXXXXX" && echo "/tmp/tmp.XXXXXXXXXX"
+}
+
 recorded_commands() {
     if [ -f "${ALL_COMMANDS}" ]; then
         cat "${ALL_COMMANDS}"
@@ -138,29 +145,30 @@ test_had_new_artifacts() {
         "had_new_artifacts ${input}"
 }
 
-test_existing_artifacts_with_artifacts() {
-    actual="$(EXISTING_ARTIFACTS='{"app1":"v1.0.0"}' existing_artifacts myorg/cicd/production pulumi)"
-    assertEquals '{"app1":"v1.0.0"}' "${actual}"
-    assertEquals \
-        "pulumi config get artifacts --cwd=pulumi/cicd --stack=myorg/cicd/production" \
-        "$(recorded_commands)"
-}
+# test_existing_artifacts_with_artifacts() {
+#     actual="$(EXISTING_ARTIFACTS='{"app1":"v1.0.0"}' existing_artifacts myorg/cicd/production pulumi)"
+#     assertEquals '{"app1":"v1.0.0"}' "${actual}"
+#     assertEquals \
+#         "pulumi config get artifacts --cwd=pulumi/cicd --stack=myorg/cicd/production" \
+#         "$(recorded_commands)"
+# }
 
-test_existing_artifacts_without_artifacts() {
-    actual="$(existing_artifacts myorg/cicd/production pulumi)"
-    assertEquals "{}" "${actual}"
-    assertEquals \
-        "pulumi config get artifacts --cwd=pulumi/cicd --stack=myorg/cicd/production" \
-        "$(recorded_commands)"
-}
+# test_existing_artifacts_without_artifacts() {
+#     actual="$(existing_artifacts myorg/cicd/production pulumi)"
+#     assertEquals "{}" "${actual}"
+#     assertEquals \
+#         "pulumi config get artifacts --cwd=pulumi/cicd --stack=myorg/cicd/production" \
+#         "$(recorded_commands)"
+# }
 
 test_update_stack_config_for_commit_with_new_artifacts_without_existing() {
     update_stack_config_for_commit "myorg/cicd/production" pulumi '{"app1":"v9.9.9","app2":"v1.0alpha"}'
 
     expected=$(
         cat << EOF
-pulumi config get artifacts --cwd=pulumi/cicd --stack=myorg/cicd/production
-git show main:pulumi/cicd/Pulumi.production.yaml
+mktemp
+git show origin/rc:pulumi/cicd/Pulumi.production.yaml
+pulumi config get artifacts --cwd=pulumi/cicd --config-file=/tmp/tmp.XXXXXXXXXX.yaml --stack=myorg/cicd/production
 pulumi config set --path artifacts.app1 v9.9.9 --cwd=pulumi/cicd --stack=myorg/cicd/production
 pulumi config set --path artifacts.app2 v1.0alpha --cwd=pulumi/cicd --stack=myorg/cicd/production
 git add --verbose pulumi/cicd/Pulumi.production.yaml
@@ -175,8 +183,9 @@ test_update_stack_config_for_commit_without_new_artifacts_without_existing() {
 
     expected=$(
         cat << EOF
-pulumi config get artifacts --cwd=pulumi/cicd --stack=myorg/cicd/production
-git show main:pulumi/cicd/Pulumi.production.yaml
+mktemp
+git show origin/rc:pulumi/cicd/Pulumi.production.yaml
+pulumi config get artifacts --cwd=pulumi/cicd --config-file=/tmp/tmp.XXXXXXXXXX.yaml --stack=myorg/cicd/production
 git add --verbose pulumi/cicd/Pulumi.production.yaml
 EOF
     )
@@ -192,8 +201,9 @@ test_update_stack_config_for_commit_with_new_artifacts_with_existing() {
 
     expected=$(
         cat << EOF
-pulumi config get artifacts --cwd=pulumi/cicd --stack=myorg/cicd/production
-git show main:pulumi/cicd/Pulumi.production.yaml
+mktemp
+git show origin/rc:pulumi/cicd/Pulumi.production.yaml
+pulumi config get artifacts --cwd=pulumi/cicd --config-file=/tmp/tmp.XXXXXXXXXX.yaml --stack=myorg/cicd/production
 pulumi config set --path artifacts.app1 v9.9.8 --cwd=pulumi/cicd --stack=myorg/cicd/production
 pulumi config set --path artifacts.app3 0.0.1 --cwd=pulumi/cicd --stack=myorg/cicd/production
 pulumi config set --path artifacts.app1 v9.9.9 --cwd=pulumi/cicd --stack=myorg/cicd/production
@@ -213,8 +223,9 @@ test_update_stack_config_for_commit_without_new_artifacts_with_existing() {
 
     expected=$(
         cat << EOF
-pulumi config get artifacts --cwd=pulumi/cicd --stack=myorg/cicd/production
-git show main:pulumi/cicd/Pulumi.production.yaml
+mktemp
+git show origin/rc:pulumi/cicd/Pulumi.production.yaml
+pulumi config get artifacts --cwd=pulumi/cicd --config-file=/tmp/tmp.XXXXXXXXXX.yaml --stack=myorg/cicd/production
 pulumi config set --path artifacts.app1 v9.9.8 --cwd=pulumi/cicd --stack=myorg/cicd/production
 pulumi config set --path artifacts.app3 0.0.1 --cwd=pulumi/cicd --stack=myorg/cicd/production
 git add --verbose pulumi/cicd/Pulumi.production.yaml
@@ -238,12 +249,14 @@ git fetch --depth=1 origin rc
 git checkout rc
 git config user.name Testy McTestface
 git config user.email tests@example.com
-git merge --no-ff --no-commit --strategy=recursive --strategy-option=ours --allow-unrelated-histories main
-pulumi config get artifacts --cwd=pulumi/cicd --stack=myorg/cicd/production
-git show main:pulumi/cicd/Pulumi.production.yaml
+git merge --no-ff --no-commit --strategy=ort --strategy-option=theirs --allow-unrelated-histories main
+mktemp
+git show origin/rc:pulumi/cicd/Pulumi.production.yaml
+pulumi config get artifacts --cwd=pulumi/cicd --config-file=/tmp/tmp.XXXXXXXXXX.yaml --stack=myorg/cicd/production
 git add --verbose pulumi/cicd/Pulumi.production.yaml
-pulumi config get artifacts --cwd=pulumi/cicd --stack=myorg/cicd/testing
-git show main:pulumi/cicd/Pulumi.testing.yaml
+mktemp
+git show origin/rc:pulumi/cicd/Pulumi.testing.yaml
+pulumi config get artifacts --cwd=pulumi/cicd --config-file=/tmp/tmp.XXXXXXXXXX.yaml --stack=myorg/cicd/testing
 git add --verbose pulumi/cicd/Pulumi.testing.yaml
 git commit --message=Create new release candidate
 

--- a/lib/rc_test.sh
+++ b/lib/rc_test.sh
@@ -145,22 +145,6 @@ test_had_new_artifacts() {
         "had_new_artifacts ${input}"
 }
 
-# test_existing_artifacts_with_artifacts() {
-#     actual="$(EXISTING_ARTIFACTS='{"app1":"v1.0.0"}' existing_artifacts myorg/cicd/production pulumi)"
-#     assertEquals '{"app1":"v1.0.0"}' "${actual}"
-#     assertEquals \
-#         "pulumi config get artifacts --cwd=pulumi/cicd --stack=myorg/cicd/production" \
-#         "$(recorded_commands)"
-# }
-
-# test_existing_artifacts_without_artifacts() {
-#     actual="$(existing_artifacts myorg/cicd/production pulumi)"
-#     assertEquals "{}" "${actual}"
-#     assertEquals \
-#         "pulumi config get artifacts --cwd=pulumi/cicd --stack=myorg/cicd/production" \
-#         "$(recorded_commands)"
-# }
-
 test_update_stack_config_for_commit_with_new_artifacts_without_existing() {
     update_stack_config_for_commit "myorg/cicd/production" pulumi '{"app1":"v9.9.9","app2":"v1.0alpha"}'
 

--- a/plugin-tester.Dockerfile
+++ b/plugin-tester.Dockerfile
@@ -1,0 +1,13 @@
+FROM buildkite/plugin-tester:latest
+
+# Add the edge repository so we can pick up a git that has the 'ort'
+# merge strategy (introduced in 2.33); the version of Alpine the
+# `buildkite/plugin-tester` container currently has is too old.
+#
+# If this ever gets updated, we can remove these two lines
+RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories
+RUN apk update && apk add git=2.34.1-r1
+
+# Add yq to make it easier to manipulate Pulumi stack files during a test.
+ARG YQ_VERSION=v4.16.2
+RUN wget https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64 -O /usr/bin/yq && chmod +x /usr/bin/yq


### PR DESCRIPTION
Previously, we were using an "ours" merge strategy option as a way to
preserve the version pins from the `rc` branch. While this worked
initially (since the only possible difference between `rc` and `main`
would be the version pins), it has since been shown to be the wrong
way to go about things. For various reasons, we have had to make
commits directly to the `rc` branch to deal with some issues that
arose from the use of shallow clones. With the "ours" strategy, this
ends up preserving these changes on the `rc` branch, regardless of
which changes have happened on `main`.

As a result, we now switch to the "theirs" strategy option, which
retains everything from the `main` branch. As a happy side effect,
this also means we can simplify our version pinning resolution
logic. Rather than doing a complicated saving of `rc` branch version
pins, capturing of the `main` branch configuration files, layering the
`rc` pins on top, and then layering the new version pins, we can rely
on the merge to give us our `main` configuration layer, and then just
extract the pins from the rc branch using `git show`. This is slightly
more straightforward, and easier to reason about.

To ensure that we are properly dealing with the commits in the right
way (as well as making sure we handle shallow clones), we now create a
small testing Git repository within the context of the integration
tests. Rather than mocking `git`, we allow the plugin to actually
perform the real `git` operations on a real repository. We also
perform some basic sanity tests to verify that the checkout we're
operating on is, in fact, shallow, and that merge logic proceeds as we
expect.

To aid in this, we have to modify the testing container a bit to
include `git`, as well as `yq` (think `jq`, but for YAML) to make our
Pulumi mocks more true-to-life (and compatible with running actual
`git` commands).