### PR TITLE
Improve logging and visibility

### DIFF
--- a/lib/log.sh
+++ b/lib/log.sh
@@ -1,7 +1,44 @@
 #!/usr/bin/env bash
 
-log() {
+# Various logging functions and helpers to make logging nice.
+
+# ANSI Formatting Codes
+########################################################################
+# Because who wants to remember all those fiddly details?
+
+# CSI = "Control Sequence Introducer"
+CSI="\e["
+END=m
+
+NORMAL=0
+BOLD=1
+
+WHITE=37
+
+RESET="${CSI}${NORMAL}${END}"
+
+function _bold_color() {
+    color="${1}"
+    shift
+    echo "${CSI}${BOLD};${color}${END}${*}${RESET}"
+}
+
+function bright_white() {
+    _bold_color "${WHITE}" "${@}"
+}
+
+# Logging
+########################################################################
+# NOTE: All logs get sent to standard error
+
+function log() {
     echo -e "${@}" >&2
+}
+
+# Handy for logging the exact command to be run, and then running it
+function log_and_run() {
+    log ❯❯ "$(bright_white "$(printf "%q " "${@}")")"
+    "$@"
 }
 
 raise_error() {

--- a/lib/rc.sh
+++ b/lib/rc.sh
@@ -222,6 +222,9 @@ create_rc() {
         --allow-unrelated-histories \
         main
 
+    echo -e "--- :git: The merge so far"
+    log_and_run git diff --staged
+
     for stack_ref in "${stack_references[@]}"; do
         update_stack_config_for_commit "${stack_ref}" "${root_dir}" "${new_artifacts}"
     done

--- a/lib/rc_test.sh
+++ b/lib/rc_test.sh
@@ -234,6 +234,7 @@ git checkout rc
 git config user.name Testy McTestface
 git config user.email tests@example.com
 git merge --no-ff --no-commit --strategy=ort --strategy-option=theirs --allow-unrelated-histories main
+git diff --staged
 mktemp
 git show origin/rc:pulumi/cicd/Pulumi.production.yaml
 pulumi config get artifacts --cwd=pulumi/cicd --config-file=/tmp/tmp.XXXXXXXXXX.yaml --stack=myorg/cicd/production


### PR DESCRIPTION
Dump even more information into the build logs to expose precisely what is going on at every step.

Read individual commit messages for further details.