### PR TITLE
Revert "Add a `git diff --staged` call to see how the merge resolved"

### DIFF
--- a/lib/rc.sh
+++ b/lib/rc.sh
@@ -222,9 +222,6 @@ create_rc() {
         --allow-unrelated-histories \
         main
 
-    echo -e "--- :git: The merge so far"
-    log_and_run git diff --staged
-
     for stack_ref in "${stack_references[@]}"; do
         update_stack_config_for_commit "${stack_ref}" "${root_dir}" "${new_artifacts}"
     done

--- a/lib/rc_test.sh
+++ b/lib/rc_test.sh
@@ -234,7 +234,6 @@ git checkout rc
 git config user.name Testy McTestface
 git config user.email tests@example.com
 git merge --no-ff --no-commit --strategy=ort --strategy-option=theirs --allow-unrelated-histories main
-git diff --staged
 mktemp
 git show origin/rc:pulumi/cicd/Pulumi.production.yaml
 pulumi config get artifacts --cwd=pulumi/cicd --config-file=/tmp/tmp.XXXXXXXXXX.yaml --stack=myorg/cicd/production


### PR DESCRIPTION
This reverts commit 6079c405c1c87345fc3bef4533436aeab8d52b64.

This appears to be causing hangs in Buildkite, for some unknown reason.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>