### PR TITLE
Update git in our testing container to 2.35.1-r0

### DIFF
--- a/plugin-tester.Dockerfile
+++ b/plugin-tester.Dockerfile
@@ -6,7 +6,7 @@ FROM buildkite/plugin-tester:latest
 #
 # If this ever gets updated, we can remove these two lines
 RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories
-RUN apk update && apk add git=2.34.1-r1
+RUN apk update && apk add git=2.35.1-r0
 
 # Add yq to make it easier to manipulate Pulumi stack files during a test.
 ARG YQ_VERSION=v4.16.2


### PR DESCRIPTION
The previous version is no longer available in the Alpine edge
repository, as revealed by our maintenance build failing this week.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>
