### PR TITLE
Remove a Bash 4-ism for dealing with possibly empty arrays

### DIFF
--- a/lib/rc.sh
+++ b/lib/rc.sh
@@ -36,11 +36,7 @@ add_artifacts() {
     # iteration. So... we just won't use standard input.)
     readarray -t lines < <(jq -r 'to_entries | .[] | [.key, .value] | @tsv' <<< "${flattened_input_json}")
 
-    # TODO: This ugly expansion can go away once we have Bash 4.4+ in
-    # CI/CD (This handles the case when the input JSON is an empty
-    # object)
-    # See https://git.savannah.gnu.org/cgit/bash.git/tree/CHANGES?id=3ba697465bc74fab513a26dea700cc82e9f4724e#n878
-    for line in "${lines[@]+${lines[@]}}"; do
+    for line in "${lines[@]}"; do
         IFS=$'\t' read -r key value <<< "${line}"
         log_and_run pulumi config set \
             --path "artifacts.${key}" \


### PR DESCRIPTION
We've got Bash 5 in CI now, so we don't have to worry about this
anymore.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>
