### PR TITLE
Update `yq` to `4.25.1` in test container image

### DIFF
--- a/plugin-tester.Dockerfile
+++ b/plugin-tester.Dockerfile
@@ -9,5 +9,5 @@ RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositori
 RUN apk update && apk add git=2.36.0-r0
 
 # Add yq to make it easier to manipulate Pulumi stack files during a test.
-ARG YQ_VERSION=v4.16.2
+ARG YQ_VERSION=v4.25.1
 RUN wget https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64 -O /usr/bin/yq && chmod +x /usr/bin/yq


### PR DESCRIPTION
I just noticed that we were rather far behind on this particular
dependency.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>
