### PR TITLE
Update and lock Buildkite images

### DIFF
--- a/.buildkite/pipeline.verify.yml
+++ b/.buildkite/pipeline.verify.yml
@@ -20,6 +20,10 @@ steps:
         command:
           - make lint-plugin
 
+      - label: ":docker: Lint Dockerfiles"
+        command:
+          - make lint-docker
+
   - group: Testing
     key: testing
     steps:

--- a/.buildkite/pipeline.verify.yml
+++ b/.buildkite/pipeline.verify.yml
@@ -1,30 +1,37 @@
+---
 env:
   PANTS_CONFIG_FILES: "['pants.toml', 'pants.ci.toml']"
   BUILDKITE_PLUGIN_VAULT_ENV_SECRET_PREFIX: "secret/data/buildkite/env"
 
 steps:
-  - label: ":lint-roller::bash: Lint Shell"
-    command:
-      - make lint-shell
-    plugins:
-      - grapl-security/vault-login#v0.1.2
-      - grapl-security/vault-env#v0.1.0:
-          secrets:
-            - grapl-rc-buildkite-plugin/TOOLCHAIN_AUTH_TOKEN
+  - group: ":lint-roller: Lints"
+    key: lints
+    steps:
+      - label: ":bash: Lint Shell"
+        command:
+          - make lint-shell
+        plugins:
+          - grapl-security/vault-login#v0.1.2
+          - grapl-security/vault-env#v0.1.0:
+              secrets:
+                - grapl-rc-buildkite-plugin/TOOLCHAIN_AUTH_TOKEN
 
-  - label: ":lint-roller::buildkite: Lint Plugin"
-    command:
-      - make lint-plugin
+      - label: ":buildkite: Lint Plugin"
+        command:
+          - make lint-plugin
 
-  - label: ":bash: Unit Test Shell"
-    command:
-      - make test-shell
-    plugins:
-      - grapl-security/vault-login#v0.1.2
-      - grapl-security/vault-env#v0.1.0:
-          secrets:
-            - grapl-rc-buildkite-plugin/TOOLCHAIN_AUTH_TOKEN
+  - group: Testing
+    key: testing
+    steps:
+      - label: ":bash: Unit Test Shell"
+        command:
+          - make test-shell
+        plugins:
+          - grapl-security/vault-login#v0.1.2
+          - grapl-security/vault-env#v0.1.0:
+              secrets:
+                - grapl-rc-buildkite-plugin/TOOLCHAIN_AUTH_TOKEN
 
-  - label: ":lint-roller::buildkite: Test Plugin"
-    command:
-      - make test-plugin
+      - label: ":buildkite: Test Plugin"
+        command:
+          - make test-plugin

--- a/BUILD
+++ b/BUILD
@@ -1,0 +1,4 @@
+docker_image(
+    name="plugin-tester",
+    source="plugin-tester.Dockerfile",
+)

--- a/Makefile
+++ b/Makefile
@@ -21,9 +21,14 @@ help: ## Print this help
 ########################################################################
 
 .PHONY: lint
+lint: lint-docker
 lint: lint-plugin
 lint: lint-shell
 lint: ## Perform lint checks on all files
+
+.PHONY: lint-docker
+lint-docker: ## Lint Dockerfiles
+	./pants filter --target-type=docker_image :: | xargs ./pants lint
 
 .PHONY: lint-plugin
 lint-plugin: ## Lint the Buildkite plugin metadata

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-COMPOSE_USER=$(shell id -u):$(shell id -g)
+DOCKER_COMPOSE_CHECK := docker compose run --rm
 PANTS_SHELL_FILTER := ./pants filter --target-type=shell_sources,shunit2_tests :: | xargs ./pants
 
 .DEFAULT_GOAL=all
@@ -32,7 +32,7 @@ lint-docker: ## Lint Dockerfiles
 
 .PHONY: lint-plugin
 lint-plugin: ## Lint the Buildkite plugin metadata
-	docker-compose run --rm plugin-linter
+	$(DOCKER_COMPOSE_CHECK) plugin-linter
 
 .PHONY: lint-shell
 lint-shell: ## Lint the shell scripts
@@ -66,4 +66,4 @@ test-plugin: ## Test the Buildkite plugin locally (does *not* run a Buildkite pi
 # Only running `build` here to ensure we have our latest changes
 # to the plugin-tester container; see plugin-tester.Dockerfile for
 # more.
-	docker-compose build && docker-compose run --rm plugin-tester
+	docker compose build && $(DOCKER_COMPOSE_CHECK) plugin-tester

--- a/Makefile
+++ b/Makefile
@@ -1,47 +1,64 @@
 COMPOSE_USER=$(shell id -u):$(shell id -g)
+PANTS_SHELL_FILTER := ./pants filter --target-type=shell_sources,shunit2_tests :: | xargs ./pants
 
 .DEFAULT_GOAL=all
 
-# Linting
+.PHONY: all
+all: format
+all: lint
+all: test
+all: ## Run all operations
+
+.PHONY: help
+help: ## Print this help
+	@awk 'BEGIN {FS = ":.*##"; printf "Usage: make <target>\n"} \
+		 /^[a-zA-Z0-9_-]+:.*?##/ { printf "  %-46s %s\n", $$1, $$2 } \
+		 /^##@/ { printf "\n%s\n", substr($$0, 5) } ' \
+		 $(MAKEFILE_LIST)
+	@printf '\n'
+
+##@ Linting
 ########################################################################
 
 .PHONY: lint
-lint: lint-plugin lint-shell
+lint: lint-plugin
+lint: lint-shell
+lint: ## Perform lint checks on all files
 
 .PHONY: lint-plugin
-lint-plugin:
+lint-plugin: ## Lint the Buildkite plugin metadata
 	docker-compose run --rm plugin-linter
 
 .PHONY: lint-shell
-lint-shell:
-	./pants lint ::
+lint-shell: ## Lint the shell scripts
+	$(PANTS_SHELL_FILTER) lint
 
-# Formatting
+##@ Formatting
 ########################################################################
 
 .PHONY: format
 format: format-shell
+format: ## Automatically format all code
 
 .PHONY: format-shell
-format-shell:
-	./pants fmt ::
+format-shell: ## Format shell scripts
+	$(PANTS_SHELL_FILTER) fmt
 
-# Testing
+##@ Testing
 ########################################################################
 
 .PHONY: test
-test: test-shell test-plugin
+test: test-shell
+test: test-plugin
+test: ## Run all tests
 
 .PHONY: test-shell
-test-shell:
+test-shell: ## Unit test shell scripts
 	./pants test ::
 
 .PHONY: test-plugin
-test-plugin:
-	# Only running `build` here to ensure we have our latest changes
-	# to the plugin-tester container; see plugin-tester.Dockerfile for
-	# more.
+test-plugin: ## Test the Buildkite plugin locally (does *not* run a Buildkite pipeline)
+# Only running `build` here to ensure we have our latest changes
+# to the plugin-tester container; see plugin-tester.Dockerfile for
+# more.
 	docker-compose build && docker-compose run --rm plugin-tester
-
-.PHONY: all
-all: format lint test

--- a/README.md
+++ b/README.md
@@ -102,6 +102,6 @@ some non-standard Pulumi reference, like `project/stack`.)
 
 ## Building
 
-Requires `make`, `docker`, and `docker-compose`.
+Requires `make`, `docker`, and Docker Compose v2.
 
 Running `make` will run all formatting, linting, and testing.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       - *read-only-plugin
 
   plugin-linter:
-    image: buildkite/plugin-linter:latest # the only available tag
+    image: buildkite/plugin-linter@sha256:833b1ce8326b038c748c8f04d317045205e115b1732a6842ec4a957f550fe357
     command: ["--id", "grapl-security/grapl-rc"]
     volumes:
       - *read-only-plugin

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 x-common-variables:
   read-only-plugin: &read-only-plugin
     # Buildkite containers assume you mount into /plugin

--- a/pants.toml
+++ b/pants.toml
@@ -1,6 +1,8 @@
 [GLOBAL]
 pants_version = "2.11.0"
 backend_packages = [
+    "pants.backend.docker",
+    "pants.backend.docker.lint.hadolint",
     "pants.backend.shell",
     "pants.backend.shell.lint.shellcheck",
     "pants.backend.shell.lint.shfmt",

--- a/plugin-tester.Dockerfile
+++ b/plugin-tester.Dockerfile
@@ -1,13 +1,17 @@
-FROM buildkite/plugin-tester:latest
+FROM buildkite/plugin-tester:v2.0.0
 
-# Add the edge repository so we can pick up a git that has the 'ort'
-# merge strategy (introduced in 2.33); the version of Alpine the
-# `buildkite/plugin-tester` container currently has is too old.
-#
-# If this ever gets updated, we can remove these two lines
-RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories
-RUN apk update && apk add git=2.36.1-r0
+# We need `git` for our tests, and it must have the 'ort' merge
+# strategy (introduced in 2.33).
+RUN apk add --no-cache git=2.34.2-r0
 
 # Add yq to make it easier to manipulate Pulumi stack files during a test.
 ARG YQ_VERSION=v4.25.1
+# https://github.com/hadolint/hadolint/wiki/DL3047
+#
+# The `wget` in this image is from busybox, and doesn't support the
+# progress-related flags that DL3047 suggests.
+#
+# This is not a large file, though, so in the end, it's not really
+# very important.
+# hadolint ignore=DL3047
 RUN wget https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64 -O /usr/bin/yq && chmod +x /usr/bin/yq

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 
-load "$BATS_PATH/load.bash"
+load "$BATS_PLUGIN_PATH/load.bash"
 
 # Uncomment to enable stub debugging
 # export PULUMI_STUB_DEBUG=/dev/tty
@@ -128,7 +128,7 @@ EOF
     # well.
 
     # Each plan line represents an expected invocation, with a list of expected
-    # arguments followed by a command to execute in case the arguments matched, 
+    # arguments followed by a command to execute in case the arguments matched,
     # separated with a colon.
     # So, in this case, we mock out the changes that each `config set` would perform
     # on the given Pulumi stack file.


### PR DESCRIPTION
Our weekly maintenance pipeline run failed, which brought this weekend's [`buildkite-plugin-tester v2.0.0 release](https://github.com/buildkite-plugins/buildkite-plugin-tester/releases/tag/v2.0.0) to our attention. It updates several bits of BATS infrastructure, but also introduces a breaking change (this is the ultimate cause of our maintenance pipeline failures).

This PR locks us to the `v2.0.0` release of the `plugin-tester` image, and addresses the breaking change.

I also noticed that our use of the `buildkite/plugin-linter` image was also pinned to `latest`, just as our `buildkite/plugin-tester` image was. There are no formal release of this image (yet :crossed_fingers:), so I've pinned it to a concrete SHA to be safe.

While making these fixes, I also took the liberty of shifting our Docker Compose usage explicitly to v2, as we have been doing across all our projects lately.

(This repository also needed some general organizational updates for the Makefile and pipeline YAML, as well as the addition of Hadolint checks, so these were also done in this PR.)