### PR TITLE
Update `buildkite/plugin-tester` to v3.0.0

### DIFF
--- a/plugin-tester.Dockerfile
+++ b/plugin-tester.Dockerfile
@@ -1,4 +1,4 @@
-FROM buildkite/plugin-tester:v2.0.0
+FROM buildkite/plugin-tester:v3.0.0
 
 # We need `git` for our tests, and it must have the 'ort' merge
 # strategy (introduced in 2.33).


### PR DESCRIPTION
https://github.com/buildkite-plugins/buildkite-plugin-tester/releases/tag/v3.0.0

Signed-off-by: Christopher Maier <chris@graplsecurity.com>
