### PR TITLE
Update `buildkite/plugin-tester` to v3.0.1

### DIFF
--- a/plugin-tester.Dockerfile
+++ b/plugin-tester.Dockerfile
@@ -1,4 +1,4 @@
-FROM buildkite/plugin-tester:v3.0.0
+FROM buildkite/plugin-tester:v3.0.1
 
 # We need `git` for our tests, and it must have the 'ort' merge
 # strategy (introduced in 2.33).


### PR DESCRIPTION
There was a big bug in v3.0.0, but one that the test suite in this
repository didn't trigger. We'll go ahead an update to remove the bug
and remove a potential source of confusion in the future.

- https://github.com/buildkite-plugins/buildkite-plugin-tester/releases/tag/v3.0.1
- https://github.com/buildkite-plugins/bats-mock/pull/8

Signed-off-by: Christopher Maier <chris@graplsecurity.com>
