### PR TITLE
Update testing image `git` to `2.34.5`

### DIFF
--- a/plugin-tester.Dockerfile
+++ b/plugin-tester.Dockerfile
@@ -2,7 +2,7 @@ FROM buildkite/plugin-tester:v3.0.1
 
 # We need `git` for our tests, and it must have the 'ort' merge
 # strategy (introduced in 2.33).
-RUN apk add --no-cache git=2.34.4-r0
+RUN apk add --no-cache git=2.34.5-r0
 
 # Add yq to make it easier to manipulate Pulumi stack files during a test.
 ARG YQ_VERSION=v4.27.5


### PR DESCRIPTION
Just a standard version bump; the old version is no longer available.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>
